### PR TITLE
添加$.http的重载方法，提高兼容性

### DIFF
--- a/src/main/java/com/ecfront/dew/common/$.java
+++ b/src/main/java/com/ecfront/dew/common/$.java
@@ -90,6 +90,21 @@ public class $ {
      */
     public static HttpHelper http = HttpHelperFactory.choose();
 
+
+
+    /**
+     * Http操作(302状态下不自动跳转)
+     *
+     * @param maxTotal                整个连接池最大连接数
+     * @param maxPerRoute             每个路由（域）的默认最大连接
+     * @param defaultConnectTimeoutMS 默认连接超时时间
+     * @param defaultSocketTimeoutMS  默认读取超时时间
+     * @param retryAble               是否重试
+     */
+    public static HttpHelper http(int maxTotal, int maxPerRoute, int defaultConnectTimeoutMS, int defaultSocketTimeoutMS, boolean retryAble) {
+        return HttpHelperFactory.choose(maxTotal, maxPerRoute, defaultConnectTimeoutMS, defaultSocketTimeoutMS, false, retryAble);
+    }
+
     /**
      * Http操作
      *


### PR DESCRIPTION
[commit:645cd1](https://github.com/gudaoxuri/dew-common/commit/645cd11d46f3efdbb3af4829a5931663eea3622e)该提交在$.http()方法中增加了一个参数Boolean autoRedirect会导致用户中心初始化失败，如图所示：

![image](https://user-images.githubusercontent.com/10736437/51301049-d0972c80-1a68-11e9-9167-473954e44d2d.png)

解决方案：
添加重载方法，兼容老的使用者：
$.http(int maxTotal, int maxPerRoute, int defaultConnectTimeoutMS, int defaultSocketTimeoutMS, boolean retryAble)
默认302状态下不自动跳转